### PR TITLE
Add multi-provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # MetaMender
 
-**MetaMender** is a lightweight, AI-powered metadata enhancer for Jellyfin.  
-It enriches your media library by rewriting short or missing overviews for music items using OpenAI — no servers, no Docker, no complexity.
+**MetaMender** is a lightweight, AI-powered metadata enhancer for Jellyfin.
+It enriches your media library by rewriting short or missing overviews for music items using your preferred language model — no servers, no Docker, no complexity.
 
 ---
 
 ## 🎯 What It Does
 
 - Scans your Jellyfin library for albums and artists with poor or missing descriptions
-- Uses OpenAI to generate high-quality, streaming-style summaries
+- Uses your configured model to generate high-quality, streaming-style summaries
 - Automatically applies changes through the Jellyfin API
 - Keeps a full log of changes with before/after text and token usage
 - Designed to be terminal-based and lightweight
@@ -22,8 +22,8 @@ It enriches your media library by rewriting short or missing overviews for music
    - Jellyfin server URL
    - Jellyfin API key
    - Your Jellyfin user ID
-   - OpenAI API key
-3. (Optional) Specify a preferred OpenAI model or item types to target.
+   - API keys for the model provider you wish to use (OpenAI, Anthropic, Google)
+3. (Optional) Specify a preferred model or item types to target and choose a `model_provider`.
 
 > Note: `config.json` is excluded from the repo to keep your credentials secure.
 
@@ -51,7 +51,7 @@ Each run generates a timestamped log in the `logs/` folder. These logs show:
 
 ## ⚠️ Error Handling
 
-If the OpenAI API returns an error for an item, MetaMender logs a warning with
+If the API returns an error for an item, MetaMender logs a warning with
 that item's ID and skips the update. These items are counted as "skipped" in the
 final summary.
 

--- a/config.template.json
+++ b/config.template.json
@@ -1,10 +1,13 @@
 {
     "jellyfin_url": "http://localhost:8096",
     "jellyfin_api_key": "your-jellyfin-api-key-here",
+    "model_provider": "openai",
     "openai_api_key": "your-openai-api-key-here",
+    "anthropic_api_key": "your-anthropic-api-key-here",
+    "google_api_key": "your-google-api-key-here",
     "user_id": "your-jellyfin-user-id",
 
     "library_id": null,
     "item_types": ["Movie", "MusicArtist", "MusicAlbum", "Series", "Episode", "Book"],
-    "openai_model": "gpt-4.1-mini"
+    "model": "gpt-4.1-mini"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 requests
 openai
+anthropic
+google-generativeai
+ollama
 tqdm


### PR DESCRIPTION
## Summary
- allow choosing model provider (OpenAI, Anthropic, Google, local)
- add optional API key fields and model option in config template
- update docs for new providers
- document new dependencies
- update `metamender.py` to dispatch to the selected provider

## Testing
- `python -m py_compile metamender.py`
- `pip install -r requirements.txt --quiet`